### PR TITLE
Refactor period collision detection and cleanup redundant methods

### DIFF
--- a/Algorithm/ExamTTSolutionManipulator.h
+++ b/Algorithm/ExamTTSolutionManipulator.h
@@ -212,10 +212,10 @@ public:
      * otherwise.
      *
      * @param exams A constant reference to a set of integers representing the exams.
-     * @param periods The period to check for collisions.
+     * @param relativePeriods The period to check for collisions.
      * @return true if there is at least one exam collision with the period, false otherwise.
      */
-    bool hasAnyExamCollisionWithAnyPeriod(const std::set<int> &exams, const std::set<int> &periods);
+    bool hasAnyExamCollisionWithAnyPeriod(const PeriodChange &change, const std::set<int> &relativePeriods);
 
     /**
      * @brief Checks if any exam in the given set is invalid for the specified period.
@@ -349,6 +349,25 @@ private:
      * the value 1 represents an unavailable room and the value -1 represents an invalid room.
      */
     std::vector<int> getPeriodRoomsAvailabilityWithout(const int &period, const std::set<int> &without);
+
+    /**
+     * Calculates the absolute period on the same day, given a base period and a relative period.
+     *
+     * This function determines the period by adding the `relativePeriod` to the `basePeriod`.
+     * It checks whether the resulting period exists within the valid range of periods and
+     * ensures that the computed period falls on the same day as the `basePeriod`.
+     *
+     * If the `relativePeriod` is zero, the function returns the `basePeriod`.
+     * If the `basePeriod` is out of the valid range or the computed period does not fall
+     * on the same day as the `basePeriod`, the function returns an empty optional.
+     *
+     * @param basePeriod The starting period, used as the reference point.
+     * @param relativePeriod The offset to be added to the `basePeriod`.
+     * @return An optional containing the resulting absolute period on the same day,
+     *         or an empty optional if the resulting period is invalid or not on the same day
+     *         as the `basePeriod`.
+     */
+    std::optional<int> getAbsolutePeriodSameDay(const int basePeriod, const int relativePeriod);
 
 };
 

--- a/Algorithm/InitialSolution.cpp
+++ b/Algorithm/InitialSolution.cpp
@@ -12,11 +12,9 @@ std::set<int> InitialSolution::getNextExam() {
 
 bool InitialSolution::scheduleExam(const std::set<int> &exams) {
     for (auto period: manipulator->getValidPeriodsForExams(exams)) {
-        auto previous = manipulator->getPreviousPeriodSameDay(period);
-        auto next = manipulator->getNextPeriodSameDay(period);
-        if (manipulator->hasAnyExamCollisionWithAnyPeriod(exams, {previous, period, next}))
-            continue;
         PeriodChange change(period, exams);
+        if (manipulator->hasAnyExamCollisionWithAnyPeriod(change, {-1, 0, 1}))
+            continue;
         if (!manipulator->tryAssignRandomRooms(randomSampleSize, change))
             continue;
         manipulator->moveExamsToPeriod(change);

--- a/Algorithm/SCHC.cpp
+++ b/Algorithm/SCHC.cpp
@@ -199,9 +199,7 @@ bool SCHC::isPeriodChangeInfeasible(const PeriodChange &change) {
         return false;
     if (manipulator_->isAnyExamInvalidInPeriod(change.moveIn, change.period))
         return true;
-    auto previous = manipulator_->getPreviousPeriodSameDay(change.period);
-    auto next = manipulator_->getNextPeriodSameDay(change.period);
-    if (manipulator_->hasAnyExamCollisionWithAnyPeriod(change.moveIn, {previous, next}))
+    if (manipulator_->hasAnyExamCollisionWithAnyPeriod(change, {-1, 1}))
         return true;
     return false;
 }

--- a/Google_tests/TestExamDataManipulator.cpp
+++ b/Google_tests/TestExamDataManipulator.cpp
@@ -179,39 +179,6 @@ TEST_F(ExamDataManipulatorTest, getAllExamsTest) {
     ASSERT_EQ(result, asserter);
 }
 
-TEST_F(ExamDataManipulatorTest, getNextPeriodSameDayTest) {
-    ExamTTDataTMP examDataTMP;
-    examDataTMP.periodDay.value() = {4, 5, 5, 5, 6};
-    auto examTTData = std::make_shared<ExamTTData>(examDataTMP);
-    auto solution = std::make_shared<ExamTTSolution>(examTTData);
-    manipulator.setSolution(solution);
-    auto result = manipulator.getNextPeriodSameDay(1);
-    int asserter = 2;
-    ASSERT_EQ(result, asserter);
-}
-
-TEST_F(ExamDataManipulatorTest, getNextPeriodSameDay_NextPeriodDifferentDay_Test) {
-    ExamTTDataTMP examDataTMP;
-    examDataTMP.periodDay.value() = {4, 5, 5, 5, 6};
-    auto examTTData = std::make_shared<ExamTTData>(examDataTMP);
-    auto solution = std::make_shared<ExamTTSolution>(examTTData);
-    manipulator.setSolution(solution);
-    auto result = manipulator.getNextPeriodSameDay(3);
-    int asserter = -1;
-    ASSERT_EQ(result, asserter);
-}
-
-TEST_F(ExamDataManipulatorTest, getNextPeriodSameDay_NoNextPeriod_Test) {
-    ExamTTDataTMP examDataTMP;
-    examDataTMP.periodDay.value() = {4, 5, 5, 5, 6};
-    auto examTTData = std::make_shared<ExamTTData>(examDataTMP);
-    auto solution = std::make_shared<ExamTTSolution>(examTTData);
-    manipulator.setSolution(solution);
-    auto result = manipulator.getNextPeriodSameDay(4);
-    int asserter = -1;
-    ASSERT_EQ(result, asserter);
-}
-
 TEST_F(ExamDataManipulatorTest, hasAnyExamCollisionWithPeriodTest) {
     ExamTTDataTMP examDataTMP;
     auto examTTData = std::make_shared<ExamTTData>(examDataTMP);
@@ -219,7 +186,7 @@ TEST_F(ExamDataManipulatorTest, hasAnyExamCollisionWithPeriodTest) {
     solution->periodExamCollisions = {{0, 1, 0, 1, 0, 1}};
     manipulator.setSolution(solution);
     std::set<int> exams = {0, 2, 4, 5};
-    ASSERT_TRUE(manipulator.hasAnyExamCollisionWithAnyPeriod(exams, {0}));
+    ASSERT_TRUE(manipulator.hasAnyExamCollisionWithAnyPeriod({0,exams}, {0}));
 }
 
 TEST_F(ExamDataManipulatorTest, hasAnyExamCollisionWithPeriod_All_Test) {
@@ -229,7 +196,7 @@ TEST_F(ExamDataManipulatorTest, hasAnyExamCollisionWithPeriod_All_Test) {
     solution->periodExamCollisions = {{0, 1, 0, 1, 0, 1}};
     manipulator.setSolution(solution);
     std::set<int> exams = {1, 3, 5};
-    ASSERT_TRUE(manipulator.hasAnyExamCollisionWithAnyPeriod(exams, {0}));
+    ASSERT_TRUE(manipulator.hasAnyExamCollisionWithAnyPeriod({0,exams}, {0}));
 }
 
 TEST_F(ExamDataManipulatorTest, hasAnyExamCollisionWithPeriod_None_Test) {
@@ -239,7 +206,7 @@ TEST_F(ExamDataManipulatorTest, hasAnyExamCollisionWithPeriod_None_Test) {
     solution->periodExamCollisions = {{0, 1, 0, 1, 0, 1}};
     manipulator.setSolution(solution);
     std::set<int> exams = {0, 2, 4};
-    ASSERT_FALSE(manipulator.hasAnyExamCollisionWithAnyPeriod(exams, {0}));
+    ASSERT_FALSE(manipulator.hasAnyExamCollisionWithAnyPeriod({0,exams}, {0}));
 }
 
 TEST_F(ExamDataManipulatorTest, hasAnyExamCollisionWithPeriod_NonePeriod_Test) {
@@ -249,7 +216,7 @@ TEST_F(ExamDataManipulatorTest, hasAnyExamCollisionWithPeriod_NonePeriod_Test) {
     solution->periodExamCollisions = {{0, 1, 0, 1, 0, 1}};
     manipulator.setSolution(solution);
     std::set<int> exams = {0, 2, 4};
-    ASSERT_FALSE(manipulator.hasAnyExamCollisionWithAnyPeriod(exams, {-1}));
+    ASSERT_FALSE(manipulator.hasAnyExamCollisionWithAnyPeriod({0,exams}, {-1}));
 }
 
 TEST_F(ExamDataManipulatorTest, getValidPeriodsForExamsTest) {


### PR DESCRIPTION
Refactor the method for detecting exam collisions with periods by using relative periods. Remove redundant methods `getNextPeriodSameDay` and `getPreviousPeriodSameDay` and their associated tests. Add `getAbsolutePeriodSameDay` to convert relative periods to absolute periods while ensuring they are on the same day.